### PR TITLE
Upate the db path handling to not using a current path

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 
 	"github.com/av-elier/nutsdb-cli/comm"
 	"github.com/av-elier/nutsdb-cli/db"
@@ -31,7 +30,7 @@ func main() {
 			},
 			cli.StringFlag{
 				Name:        "db",
-				Usage:       "path to nutsdb batabase",
+				Usage:       "path to nutsdb database",
 				Destination: &args.db,
 				Required:    true,
 			},
@@ -39,18 +38,16 @@ func main() {
 		Commands: []cli.Command{
 			{
 				Name:  "debug",
-				Usage: "Create debug database 'test.db' in cwd",
+				Usage: "Insert sample data into the specified database",
 				Action: func(c *cli.Context) error {
-					cwd, _ := os.Getwd()
-					impl := db.NutsDB{DbDir: path.Join(cwd, args.db)}
+					impl := db.NutsDB{DbDir: args.db}
 					impl.CreateDebugDb()
 					return nil
 				},
 			},
 		},
 		Action: func(c *cli.Context) error {
-			cwd, _ := os.Getwd()
-			nuts := db.NutsDB{DbDir: path.Join(cwd, args.db)}
+			nuts := db.NutsDB{DbDir: args.db}
 			var in io.ReadCloser = os.Stdin
 			if args.command != "" {
 				in = ioutil.NopCloser(bytes.NewReader([]byte(args.command)))


### PR DESCRIPTION
Update the db path handling to not using a current path.

  - I already have nutsdb database files. 
    - ex) /home/ubuntu/go/src/github.com/cloud-barista/cb-spider/meta_db/dat/*.dat
  - I want to explore my data using nutsdb-cli in any path.

- Before:
  - The CLI is only executed using the db file under the current path.
 
- After:
  - I can explore my nutsdb data in any path.
 
But, If you have a reason with current path version, you can close this PR.